### PR TITLE
Add ClientOptions struct to be able to override the default timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ func main() {
 	apiKey := "pplx-xxx" // Replace with your actual API key
 	model := perplexity.ModelLlama3SonarSmall32kChat
 
-	client := perplexity.NewClient(apiKey, model)
+	// You can omit the opts parameter to use the default 30-second timeout
+	opts := &perplexity.ClientOptions{
+		RequestTimeoutInSeconds: 100,
+    }
+	client := perplexity.NewClient(apiKey, model, opts)
 
 	request := perplexity.ChatCompletionRequest{
 		Messages: []perplexity.Message{

--- a/perplexity.go
+++ b/perplexity.go
@@ -67,6 +67,11 @@ type ChatCompletionResponse struct {
 	} `json:"usage"`
 }
 
+// ClientOptions represents additional options to adjust the client behavior
+type ClientOptions struct {
+	RequestTimeoutInSeconds time.Duration
+}
+
 func (r ChatCompletionResponse) isSingle() bool {
 	return len(r.Choices) == 1
 }
@@ -106,13 +111,21 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
+var defaultClientOptions = &ClientOptions{
+	RequestTimeoutInSeconds: 30,
+}
+
 // NewClient creates a new Perplexity API client
-func NewClient(apiKey, model string) *Client {
+func NewClient(apiKey, model string, options *ClientOptions) *Client {
+	if options == nil {
+		options = defaultClientOptions
+	}
+
 	return &Client{
 		APIKey: apiKey,
 		Model:  model,
 		HTTPClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: options.RequestTimeoutInSeconds * time.Second,
 		},
 	}
 }


### PR DESCRIPTION
## Description

Hey 👋 

First of all, thanks for the lib. I have been working with a different one, but unfortunately it didn't allow to finetune the request with all the settings the Perplexity API providers. This library does it better, however it has the request timeout value hardcoded. In some scenarios, such as long content generation, it merely exits ahead of time. 

This PR extends the client configuration without introducing breaking changes. 